### PR TITLE
Split out some specific events from the all events trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,8 @@
 name: CI
 
 on:
-  push:
-    branches-ignore:
-      - main
-
-  # Allows you to run this workflow manually from the Actions tab
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/creates/payment_create_realtime.js
+++ b/creates/payment_create_realtime.js
@@ -1,6 +1,6 @@
 
 const { BASE_URL } = require('../constants');
-const { PaymentSample, PaymentOutputFields } = require('../samples/payment');
+const { paymentSample, singlePaymentOutputFields } = require('../samples/sample_payment');
 
 const createPayment = (z, bundle) => {
   const options = {
@@ -125,8 +125,8 @@ module.exports = {
         altersDynamicFields: false,
       },
     ],
-    sample: PaymentSample,
-    outputFields: PaymentOutputFields,
+    sample: paymentSample,
+    outputFields: singlePaymentOutputFields,
   },
   key: 'payment_create_realtime',
   noun: 'Payment',

--- a/creates/payment_create_scheduled.js
+++ b/creates/payment_create_scheduled.js
@@ -1,6 +1,6 @@
 
 const { BASE_URL } = require('../constants');
-const { PaymentSample, PaymentOutputFields } = require('../samples/payment');
+const { paymentSample, singlePaymentOutputFields } = require('../samples/sample_payment');
 
 
 const createPayment = (z, bundle) => {
@@ -73,8 +73,8 @@ module.exports = {
         altersDynamicFields: false,
       },
     ],
-    sample: PaymentSample,
-    outputFields: PaymentOutputFields,
+    sample: paymentSample,
+    outputFields: singlePaymentOutputFields,
   },     
   key: 'payment_create_scheduled',
   noun: 'Payment',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinch-payments",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Pinch is a PCI Compliant, Australian payments platform offering automated Bank Account Direct Debit and Credit Card payments for standard and repeating invoices or standalone transactions.",
   "main": "index.js",
   "scripts": {

--- a/samples/sample_payer.js
+++ b/samples/sample_payer.js
@@ -1,0 +1,14 @@
+module.exports = {
+    id: "pyr_XXXXXXXXXXXXXX",
+    firstName: "John",
+    lastName: "Smith",
+    emailAddress: "pinch+zapier@mailinator.com",
+    mobileNumber: null,
+    streetAddress: null,
+    suburb: null,
+    postcode: null,
+    state: null,
+    country: null,
+    companyName: null,
+    metadata: ""
+}

--- a/samples/sample_payment.js
+++ b/samples/sample_payment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PaymentSample = {
+const paymentSample = {
     id: 'pmt_XXXXXXXXXXXXXX',
     attemptId: 'att_XXXXXXXX',
     amount: 1000,
@@ -29,7 +29,11 @@ const PaymentSample = {
       companyRegistrationNumber: null,
       metadata: null,
     },
-    subscription: null,
+    subscription: {
+        id: "sub_XXXXXXXXXXXXXX",
+        planId: "pln_XXXXXXXXXXXXXX",
+        planName: "Monthly Payments"
+    },
     attempts: [
       {
         id: 'att_XXXXXXXX',
@@ -77,8 +81,7 @@ const PaymentSample = {
     metadata: null,
 };
 
-
-const PaymentOutputFields = [
+const corePaymentOutputFields = [
   { key: 'id', type: 'string' },
   { key: 'attemptId', type: 'string' },
   { key: 'amount', type: 'integer' },
@@ -105,7 +108,14 @@ const PaymentOutputFields = [
   { key: 'payer__companyName', type: 'string' },
   { key: 'payer__companyRegistrationNumber', type: 'string' },
   { key: 'payer__metadata', dict: true },
-  { key: 'subscription' },
+  { key: 'subscription__id', type: 'string' },
+  { key: 'subscription__planId', type: 'string' },
+  { key: 'subscription__planName', type: 'string' },
+  { key: 'metadata', dict: true },
+];
+
+const singlePaymentOutputFields = [
+  ...corePaymentOutputFields,
   { key: 'attempts[]id', type: 'string' },
   { key: 'attempts[]amount', type: 'integer' },
   { key: 'attempts[]currency', type: 'string' },
@@ -141,11 +151,30 @@ const PaymentOutputFields = [
   { key: 'attempts[]fees__convertedTotalFee', type: 'number' },
   { key: 'attempts[]fees__convertedCurrency', type: 'string' },
   { key: 'attempts[]fees__conversionRate', type: 'number' },
-  { key: 'attempts[]status' },
-  { key: 'metadata', dict: true },
+  { key: 'attempts[]status' }
 ];
 
+const eventSinglePaymentOutputFields = () => {
+  var eventPaymentOutputs = [];
+  corePaymentOutputFields.forEach(field => {
+    var fieldClone = structuredClone(field);
+    fieldClone.key = 'data__payment__' + fieldClone.key;
+    eventPaymentOutputs.push(fieldClone);
+  });
+};
+
+const eventProcessedPaymentsOutputFields = () => {
+  var eventPaymentOutputs = [];
+  corePaymentOutputFields.forEach(field => {
+    var fieldClone = structuredClone(field);
+    fieldClone.key = 'data__payments[]' + fieldClone.key;
+    eventPaymentOutputs.push(fieldClone);
+  });
+};
+
 module.exports = {
-    PaymentSample,
-    PaymentOutputFields
+    paymentSample,
+    singlePaymentOutputFields,
+    eventSinglePaymentOutputFields,
+    eventProcessedPaymentsOutputFields
 };

--- a/triggers/evt_payer_created.js
+++ b/triggers/evt_payer_created.js
@@ -1,0 +1,54 @@
+const { BASE_URL } = require('../constants');
+const samplePayer = require('../samples/sample_issue');
+
+const perform = (z, bundle) => {
+  const options = {
+    url: `${BASE_URL}/${bundle.authData.environment}/events`,
+    method: 'GET',
+    headers: { },
+    params: {
+      page: bundle.meta.page + 1,
+      eventType: 'payer-created',
+    },
+  };
+
+  return z.request(options).then((response) => {
+    response.throwForStatus();
+    const results = response.data;
+    return results.data;
+  });
+};
+
+module.exports = {
+  operation: {
+    perform: perform,
+    canPaginate: true,
+    inputFields: [],
+    sample: {
+      id: 'evt_XXXXXXXXXXXXXX',
+      type: 'payer-created',
+      eventDate: '2024-01-01T01:01:00Z',
+      metadata: { payerName: "John Smith" },
+      data: {
+        payer: samplePayer
+      }
+    },
+    outputFields: [
+      { key: 'id', type: 'string' },
+      { key: 'type', type: 'string' },
+      { key: 'eventDate', type: 'datetime' },
+      { key: 'metadata', dict: true },
+      { key: 'data__payer__id', type: 'string' },
+      { key: 'data__payer__firstName', type: 'string' },
+      { key: 'data__payer__lastName', type: 'string' },
+      { key: 'data__payer__emailAddress', type: 'string' },
+      { key: 'data__payer__companyName', type: 'string' }
+    ],
+  },
+  key: 'evt_payer_created',
+  noun: 'Event',
+  display: {
+    label: 'Payer Created Event',
+    description: 'Triggers when a Payer is created.'
+  },
+};

--- a/triggers/evt_payer_updated.js
+++ b/triggers/evt_payer_updated.js
@@ -1,0 +1,54 @@
+const { BASE_URL } = require('../constants');
+const samplePayer = require('../samples/sample_issue');
+
+const perform = (z, bundle) => {
+  const options = {
+    url: `${BASE_URL}/${bundle.authData.environment}/events`,
+    method: 'GET',
+    headers: { },
+    params: {
+      page: bundle.meta.page + 1,
+      eventType: 'payer-updated',
+    },
+  };
+
+  return z.request(options).then((response) => {
+    response.throwForStatus();
+    const results = response.data;
+    return results.data;
+  });
+};
+
+module.exports = {
+  operation: {
+    perform: perform,
+    canPaginate: true,
+    inputFields: [],
+    sample: {
+      id: 'evt_XXXXXXXXXXXXXX',
+      type: 'payer-updated',
+      eventDate: '2024-01-01T01:01:00Z',
+      metadata: { payerName: "John Smith" },
+      data: {
+        payer: samplePayer
+      }
+    },
+    outputFields: [
+      { key: 'id', type: 'string' },
+      { key: 'type', type: 'string' },
+      { key: 'eventDate', type: 'datetime' },
+      { key: 'metadata', dict: true },
+      { key: 'data__payer__id', type: 'string' },
+      { key: 'data__payer__firstName', type: 'string' },
+      { key: 'data__payer__lastName', type: 'string' },
+      { key: 'data__payer__emailAddress', type: 'string' },
+      { key: 'data__payer__companyName', type: 'string' }
+    ],
+  },
+  key: 'evt_payer_updated',
+  noun: 'Event',
+  display: {
+    label: 'Payer Updated Event',
+    description: 'Triggers when a Payer is updated.'
+  },
+};

--- a/triggers/evt_realtime_payment.js
+++ b/triggers/evt_realtime_payment.js
@@ -1,0 +1,47 @@
+const { BASE_URL } = require('../constants');
+const { PaymentSample, eventSinglePaymentOutputFields } = require('../samples/sample_payment');
+
+const perform = (z, bundle) => {
+  const options = {
+    url: `${BASE_URL}/${bundle.authData.environment}/events`,
+    method: 'GET',
+    headers: { },
+    params: {
+      page: bundle.meta.page + 1,
+      eventType: 'realtime-payment',
+    },
+  };
+
+  return z.request(options).then((response) => {
+    response.throwForStatus();
+    const results = response.data;
+    return results.data;
+  });
+};
+
+module.exports = {
+  operation: {
+    perform: perform,
+    canPaginate: true,
+    inputFields: [],
+    sample: {
+      id: 'evt_XXXXXXXXXXXXXX',
+      type: 'realtime-payment',
+      eventDate: '2024-01-01T01:01:00Z',
+      metadata: { 
+        status: "approved",
+        amount: 1000
+      },
+      data: {
+        payment: PaymentSample
+      }
+    },
+    outputFields: eventSinglePaymentOutputFields(),
+  },
+  key: 'evt_realtime_payment',
+  noun: 'Event',
+  display: {
+    label: 'Realtime Payment Event',
+    description: 'Triggers when a realtime Payment occurs.'
+  },
+};

--- a/triggers/evt_scheduled_process.js
+++ b/triggers/evt_scheduled_process.js
@@ -1,0 +1,49 @@
+const { BASE_URL } = require('../constants');
+const { paymentSample, eventProcessedPaymentsOutputFields } = require('../samples/sample_payment');
+
+const perform = (z, bundle) => {
+  const options = {
+    url: `${BASE_URL}/${bundle.authData.environment}/events`,
+    method: 'GET',
+    headers: { },
+    params: {
+      page: bundle.meta.page + 1,
+      eventType: 'scheduled-process',
+    },
+  };
+
+  return z.request(options).then((response) => {
+    response.throwForStatus();
+    const results = response.data;
+    return results.data;
+  });
+};
+
+module.exports = {
+  operation: {
+    perform: perform,
+    canPaginate: true,
+    inputFields: [],
+    sample: {
+      id: 'evt_XXXXXXXXXXXXXX',
+      type: 'scheduled-process',
+      eventDate: '2024-01-01T01:01:00Z',
+      metadata: { 
+        status: "approved",
+        amount: 1000
+      },
+      data: {
+        payments: [
+          paymentSample
+        ]
+      }
+    },
+    outputFields: eventProcessedPaymentsOutputFields,
+  },
+  key: 'evt_scheduled_process',
+  noun: 'Event',
+  display: {
+    label: 'Scheduled Process Event',
+    description: 'Triggers when a Scheduled Payments are processed.'
+  },
+};


### PR DESCRIPTION
This means the events can be defined better and easier to use for integrators.

So far I have added these 4 so that I can test them out before adding the rest:
payer-created
payer-updated
realtime-payment
scheduled-process
